### PR TITLE
Develop

### DIFF
--- a/install-piface-real-time-clock.sh
+++ b/install-piface-real-time-clock.sh
@@ -39,24 +39,59 @@ set_revision_var() {
 # DESCRIPTION: Load the I2C modules and send magic number to RTC, on boot.
 #=======================================================================
 start_on_boot() {
-    echo "Changing /etc/rc.local to load time from PiFace Clock."
-    # remove exit 0
-    sed -i "s/exit 0//" /etc/rc.local
-
+    echo "Create a new pifaceShimRtc init script to load time from PiFace Clock."
+    echo "Adding /etc/init.d/pifaceShimRtc."
+    
     if [[ $RPI_REVISION == "1" ]]; then
         i=0  # i2c-0
     else
         i=1  # i2c-1
     fi
 
-    cat >> /etc/rc.local << EOF
-modprobe i2c-dev
-# Calibrate the clock (default: 0x47). See datasheet for MCP7940N
-i2cset -y $i 0x6f 0x08 0x47
-modprobe i2c:mcp7941x
-echo mcp7941x 0x6f > /sys/class/i2c-dev/i2c-$i/device/new_device
-hwclock --hctosys
+    cat > /etc/init.d/pifaceShimRtc << EOF
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          piface-shim-rtc
+# Required-Start:    udev mountkernfs \$remote_fs raspi-config
+# Required-Stop:
+# Default-Start:     S
+# Default-Stop:
+# Short-Description: Add the piface Shim RTC
+# Description:       Add the piface Shim RTC 
+### END INIT INFO
+
+. /lib/lsb/init-functions
+
+case "\$1" in
+  start)
+    log_success_msg "Probe the i2c-dev"
+    modprobe i2c-dev
+    # Calibrate the clock (default: 0x47). See datasheet for MCP7940N
+    log_success_msg "Calibrate the clock"
+    i2cset -y $i 0x6f 0x08 0x47
+    log_success_msg "Probe the mcp7941x driver"
+    modprobe i2c:mcp7941x
+    log_success_msg "Add the mcp7941x device in the sys filesystem"
+    echo mcp7941x 0x6f > /sys/class/i2c-dev/i2c-$i/device/new_device
+    log_success_msg "Synchronize de system and hardware rtc clock"
+    hwclock --hctosys
+    ;;
+  stop)
+    ;;
+  restart)
+    ;;
+  force-reload)
+    ;;
+  *)
+    echo "Usage: \$0 start" >&2
+    exit 3
+    ;;
+esac
 EOF
+    chmod +x /etc/init.d/pifaceShimRtc
+
+    echo "Install the pifaceShimRtc init script"
+    update-rc.d pifaceShimRtc defaults
 }
 
 #=======================================================================
@@ -85,5 +120,5 @@ else
 fi
 echo ""
 echo '    sudo date -s "14 JAN 2014 10:10:30"'
-echo "    hwclock --systohc"
+echo "    sudo hwclock --systohc"
 echo ""


### PR DESCRIPTION
Hello Thomas,

I replace the modification of /etc/rc.local by a new script in /etc/init.d

I do this because I need the system clock be ready before execution of some another script on my own which it's activated very early on the boot of the raspberry system.

I think I'm not the only one to need this so I made a pull request for this modification.

By the way, I've also met some conflict with your script and ntp daemon. It's seem to be in conflict by trying to write some value in the hardware rtc before it's ready ? My modification have solve this conflict for me.

Best regards 
